### PR TITLE
feat: add ContactPage reuse Contact component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import BreachCheckPage from './pages/BreachCheckPage.jsx';
 import BreachCheckPage from './pages/BreachCheckPage.jsx';
 import SurfacePage from './pages/SurfacePage.jsx';
 import ActivityLog from './pages/ActivityLog.jsx';
+import ContactPage from './pages/ContactPage.jsx';
 import LoadingSpinner from './components/LoadingSpinner.jsx';
 import AdminDashboard from './pages/AdminDashboard.jsx';
 import AdminRoute from './components/AdminRoute.jsx';
@@ -152,6 +153,10 @@ function AppRoutes() {
               <SurfacePage />
             </ProtectedRoute>
           }
+        />
+        <Route
+          path="/contact"
+          element={<ContactPage />}
         />
         <Route
           path="/admin"

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -31,7 +31,7 @@ const Navbar = () => {
     { name: 'About', href: '#about' },
     { name: 'Features', href: '#features' },
     { name: 'Testimonials', href: '#testimonials' },
-    { name: 'Contact', href: '#contact' }
+    { name: 'Contact', href: '/contact' }
   ];
 
   return (

--- a/src/pages/ContactPage.css
+++ b/src/pages/ContactPage.css
@@ -1,0 +1,24 @@
+.contact-page {
+  padding: 3rem 0;
+  min-height: 70vh;
+  background: var(--bg-app, #f7f7fb);
+}
+
+.page-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.page-title {
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--text-dark, #222);
+}
+
+.page-subtitle {
+  color: var(--text-muted, #666);
+  margin-bottom: 1.5rem;
+}
+
+/* Reuse component styles from Contact.css. No additional styles required */

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Contact from '../components/Contact/Contact';
+import './ContactPage.css';
+
+const ContactPage = () => {
+  return (
+    <div className="contact-page">
+      <div className="page-container">
+        <h1 className="page-title">Contact Support</h1>
+        <p className="page-subtitle">Send inquiries or feedback directly to our support team.</p>
+        <Contact />
+      </div>
+    </div>
+  );
+};
+
+export default ContactPage;


### PR DESCRIPTION
# Contact Form Implementation - PR

## Summary
This PR implements a dedicated Contact page that reuses the existing `Contact` component to provide a simple contact form for users to send inquiries or feedback directly to the support team.

## Changes
- Added `src/pages/ContactPage.jsx` - new page that renders the existing `Contact` component
- Added `src/pages/ContactPage.css` - light page-level styles
- Added route `/contact` in `src/App.jsx`
- Updated `src/components/Navbar/Navbar.jsx` to link `Contact` to `/contact` (desktop and mobile)

## Behavior
- Accessible at `/contact` (public)
- The form currently simulates submission (as the `Contact` component did previously). Future improvement: wire to a backend API endpoint for persistence and email notifications.

## Commits
- feat: add ContactPage reuse Contact component

## Testing Checklist
- [ ] Navigate to `/contact` and verify page shows the contact header and form
- [ ] Submitting the form shows the success message
- [ ] Navbar Contact link navigates to `/contact`
- [ ] Landing page anchor `#contact` still scrolls to the contact section

## Related Issue
Closes #142
